### PR TITLE
add updateInterval to statement. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "livy-client",
-  "version": "0.0.10",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "tsc --watch",
     "livy-server": "docker-compose up -d",
     "prepublishOnly": "tsc",
-    "postinstall": "tsc --outDir ./dist"  
+    "postinstall": "tsc --outDir ./lib"
   },
   "author": "Yuhsak Inoue",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "build": "tsc --watch",
     "livy-server": "docker-compose up -d",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc",
+    "postinstall": "tsc --outDir ./dist"  
   },
   "author": "Yuhsak Inoue",
   "license": "MIT",

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -44,7 +44,7 @@ export default class Batch extends Client<BatchSession[]> {
 	}
 
 	Session(s:LivyBatchSession, {autoupdate=true}:{autoupdate?:boolean}={}) {
-		return new BatchSession(s, {protocol: this.protocol, host: this.host, port: this.port, headers: this.headers, autoupdate})
+		return new BatchSession(s, {protocol: this.protocol, host: this.host, port: this.port, pathPrefix: this.pathPrefix, headers: this.headers, autoupdate})
 	}
 
 	cleanup() {

--- a/src/client.ts
+++ b/src/client.ts
@@ -35,11 +35,10 @@ export default class Client<ObjectType=any> extends EventEmitter {
 	public updateInterval: number
 	public agent: AxiosInstance
 	public path: string
-	public pathPrefix: string
 	protected headers?: any
 	protected o:ObjectType
 
-	constructor({protocol='http', host='localhost', port=8998, autoupdate=false, updateInterval=1000, headers, agent}:ClientConstructorArguments={}) {
+	constructor({protocol='http', host='localhost', port=8998, autoupdate=false, updateInterval=1000, pathPrefix="",headers, agent}:ClientConstructorArguments={}) {
 		super()
 		this.protocol = protocol
 		this.host = host
@@ -47,14 +46,16 @@ export default class Client<ObjectType=any> extends EventEmitter {
 		this.autoupdate = autoupdate
 		this.updateInterval = updateInterval
 		this.headers = headers
+		let baseURL = ""
+		if (port && host) baseURL = `${this.protocol}://${this.host}:${this.port}`
+		baseURL += pathPrefix;
 		this.agent = agent || Axios.create({...{
-			baseURL: `${this.protocol}://${this.host}:${this.port}`,
+			baseURL: baseURL,
 			responseType: 'json',
 			timeout: 10*1000
 		}, ...(headers?{headers}:{})})
 		this.o = <any>{}
 		this.path = ""
-		this.pathPrefix = ""
 		this.autoupdate && this.update()
 		this.on('requestError', e=>this.emit('error', e))
 	}
@@ -92,7 +93,7 @@ export default class Client<ObjectType=any> extends EventEmitter {
 	private async request(method:Method='get', path:string, data?:any) {
 		const opt = Object.assign({
 			method,
-			url: this.pathPrefix + path
+			url: path
 		}, data?{data}:{})
 		return new Promise<AxiosResponse['data']>((resolve, reject)=>
 			this.agent.request(opt)

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,8 +17,8 @@ export type RequestError = {
 
 export type ClientConstructorArguments = {
 	protocol?: string
-	host?: string
-	port?: string|number
+	host?: string | null
+	port?: string|number|null
 	pathPrefix?: string
 	autoupdate?: boolean
 	updateInterval?: number

--- a/src/client.ts
+++ b/src/client.ts
@@ -51,6 +51,7 @@ export default class Client<ObjectType=any> extends EventEmitter {
 			timeout: 10*1000
 		}, ...(headers?{headers}:{})})
 		this.o = <any>{}
+		this.path = ""
 		this.autoupdate && this.update()
 		this.on('requestError', e=>this.emit('error', e))
 	}
@@ -110,7 +111,7 @@ export default class Client<ObjectType=any> extends EventEmitter {
 	}
 
 	async update() {
-		this.path && this.status().then(this.updateState.bind(this)).catch(()=>{})
+		this.path && this.path!="" && this.status().then(this.updateState.bind(this)).catch(()=>{})
 		this.autoupdate && sleep(this.updateInterval).then(this.update.bind(this))
 		return this
 	}

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,6 +19,7 @@ export type ClientConstructorArguments = {
 	protocol?: string
 	host?: string
 	port?: string|number
+	pathPrefix?: string
 	autoupdate?: boolean
 	updateInterval?: number
 	headers?: any,
@@ -34,6 +35,7 @@ export default class Client<ObjectType=any> extends EventEmitter {
 	public updateInterval: number
 	public agent: AxiosInstance
 	public path: string
+	public pathPrefix: string
 	protected headers?: any
 	protected o:ObjectType
 
@@ -52,6 +54,7 @@ export default class Client<ObjectType=any> extends EventEmitter {
 		}, ...(headers?{headers}:{})})
 		this.o = <any>{}
 		this.path = ""
+		this.pathPrefix = ""
 		this.autoupdate && this.update()
 		this.on('requestError', e=>this.emit('error', e))
 	}
@@ -89,7 +92,7 @@ export default class Client<ObjectType=any> extends EventEmitter {
 	private async request(method:Method='get', path:string, data?:any) {
 		const opt = Object.assign({
 			method,
-			url: path
+			url: this.pathPrefix + path
 		}, data?{data}:{})
 		return new Promise<AxiosResponse['data']>((resolve, reject)=>
 			this.agent.request(opt)

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,8 +29,9 @@ export type ClientConstructorArguments = {
 export default class Client<ObjectType=any> extends EventEmitter {
 
 	public protocol: string
-	public host: string
-	public port: string|number
+	public host: string|null
+	public pathPrefix: string
+	public port: string|number|null
 	public autoupdate: boolean
 	public updateInterval: number
 	public agent: AxiosInstance
@@ -47,8 +48,9 @@ export default class Client<ObjectType=any> extends EventEmitter {
 		this.updateInterval = updateInterval
 		this.headers = headers
 		let baseURL = ""
+		this.pathPrefix = pathPrefix
 		if (port && host) baseURL = `${this.protocol}://${this.host}:${this.port}`
-		baseURL += pathPrefix;
+		baseURL += this.pathPrefix;
 		this.agent = agent || Axios.create({...{
 			baseURL: baseURL,
 			responseType: 'json',

--- a/src/client.ts
+++ b/src/client.ts
@@ -50,7 +50,6 @@ export default class Client<ObjectType=any> extends EventEmitter {
 			responseType: 'json',
 			timeout: 10*1000
 		}, ...(headers?{headers}:{})})
-		this.path = '/'
 		this.o = <any>{}
 		this.autoupdate && this.update()
 		this.on('requestError', e=>this.emit('error', e))

--- a/src/livy-client.ts
+++ b/src/livy-client.ts
@@ -44,11 +44,11 @@ export default class LivyClient extends Client<Session[]> {
 	}
 
 	Session(s:LivySession, {autoupdate=true}:{autoupdate?:boolean}={}) {
-		return new Session(s, {protocol: this.protocol, host: this.host, port: this.port, headers: this.headers, autoupdate})
+		return new Session(s, {protocol: this.protocol, host: this.host, port: this.port, pathPrefix: this.pathPrefix, headers: this.headers, autoupdate})
 	}
 
 	Batch({autoupdate=false}:{autoupdate?: boolean}={}) {
-		return new Batch({protocol: this.protocol, host: this.host, port: this.port, headers: this.headers, autoupdate})
+		return new Batch({protocol: this.protocol, host: this.host, port: this.port, pathPrefix: this.pathPrefix, headers: this.headers, autoupdate})
 	}
 
 	cleanup() {

--- a/src/session.ts
+++ b/src/session.ts
@@ -83,13 +83,13 @@ export default class Session extends Stateful<LivySession, LivySessionAvailabili
 		return this.get(`${this.path}/statements`).then(r=>r.statements ? r.statements.map((s:LivyStatement)=>this.Statement(s, {autoupdate: false})) : [])
 	}
 
-	async run(param: {code: string, kind?: LivySessionKind}, {autoupdate=true}:{autoupdate?: boolean}={}) {
+	async run(param: {code: string, kind?: LivySessionKind}, {autoupdate=true,updateInterval=1000}:{autoupdate?: boolean,updateInterval?:number}={}) {
 		const res = await this.post(`${this.path}/statements`, param)
-		return this.Statement(res, {autoupdate})
+		return this.Statement(res, {autoupdate,updateInterval})
 	}
 
-	Statement(s:LivyStatement, {autoupdate=true}={}) {
-		return new Statement(s, this.o, {protocol: this.protocol, host: this.host, port: this.port, headers: this.headers, autoupdate})
+	Statement(s:LivyStatement, {autoupdate=true, updateInterval=1000}={}) {
+		return new Statement(s, this.o, {protocol: this.protocol, host: this.host, port: this.port, headers: this.headers, autoupdate, updateInterval})
 	}
 
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -89,7 +89,7 @@ export default class Session extends Stateful<LivySession, LivySessionAvailabili
 	}
 
 	Statement(s:LivyStatement, {autoupdate=true, updateInterval=1000}={}) {
-		return new Statement(s, this.o, {protocol: this.protocol, host: this.host, port: this.port, headers: this.headers, autoupdate, updateInterval})
+		return new Statement(s, this.o, {protocol: this.protocol, host: this.host, port: this.port, pathPrefix: this.pathPrefix, headers: this.headers, autoupdate, updateInterval})
 	}
 
 }


### PR DESCRIPTION
currently you can set the interval for a session but there are cases where you need a certain statement to return quickly. this adds the updateinterval param to the statement.
also removes empty path in client that causes access to 8998 homepage with an error message.
